### PR TITLE
FILE-26: Return status code 500 on empty response from clamd

### DIFF
--- a/app/uk/gov/hmrc/avscanner/clamav/ClamAntiVirus.scala
+++ b/app/uk/gov/hmrc/avscanner/clamav/ClamAntiVirus.scala
@@ -28,13 +28,16 @@ trait ClamAvResponseInterpreter {
   import uk.gov.hmrc.avscanner.config.ClamAvConfig.clamAvConfig
 
   def interpretResponseFromClamd(responseFromClamd: String): Unit = {
-    Logger.debug("response: " + responseFromClamd)
-    if (!clamAvConfig.okClamAvResponse.equals(responseFromClamd)) {
-      Logger.warn(s"Virus detected : $responseFromClamd")
-      throw new VirusDetectedException(responseFromClamd)
+    responseFromClamd match {
+      case clamAvConfig.okClamAvResponse =>
+        Logger.info("File clean")
+      case "" =>
+        Logger.warn("Empty response from clamd")
+        throw new ClamAvFailedException("Empty response from clamd")
+      case _ =>
+        Logger.warn(s"Virus detected : $responseFromClamd")
+        throw new VirusDetectedException(responseFromClamd)
     }
-
-    Logger.info("File clean")
   }
 }
 
@@ -101,3 +104,4 @@ class ClamAntiVirus() extends ClamAvResponseInterpreter {
 }
 
 class VirusDetectedException(val virusInformation: String) extends Exception(s"Virus detected: $virusInformation")
+class ClamAvFailedException(val message: String) extends Exception(message)

--- a/app/uk/gov/hmrc/avscanner/clamav/ClamAntiVirus.scala
+++ b/app/uk/gov/hmrc/avscanner/clamav/ClamAntiVirus.scala
@@ -41,7 +41,12 @@ trait ClamAvResponseInterpreter {
   }
 }
 
-class ClamAntiVirus() extends ClamAvResponseInterpreter {
+trait VirusChecker {
+  def sendBytesToClamd(bytes: Array[Byte])(implicit ec : ExecutionContext): Future[Unit]
+  def checkForVirus()(implicit ec : ExecutionContext): Future[Unit]
+}
+
+class ClamAntiVirus() extends ClamAvResponseInterpreter with VirusChecker {
 
   import uk.gov.hmrc.avscanner.config.ClamAvConfig.clamAvConfig
 
@@ -51,7 +56,7 @@ class ClamAntiVirus() extends ClamAvResponseInterpreter {
 
   toClam.write(clamAvConfig.instream.getBytes())
 
-  def sendBytesToClamd(bytes: Array[Byte])(implicit ec : ExecutionContext): Future[Unit] = {
+  override def sendBytesToClamd(bytes: Array[Byte])(implicit ec : ExecutionContext): Future[Unit] = {
     Future{
       toClam.writeInt(bytes.length)
       toClam.write(bytes)
@@ -59,7 +64,7 @@ class ClamAntiVirus() extends ClamAvResponseInterpreter {
     }
   }
 
-  def checkForVirus()(implicit ec : ExecutionContext): Future[Unit] = {
+  override def checkForVirus()(implicit ec : ExecutionContext): Future[Unit] = {
     Future {
       try {
         toClam.writeInt(0)

--- a/app/uk/gov/hmrc/avscanner/controllers/AvScannerController.scala
+++ b/app/uk/gov/hmrc/avscanner/controllers/AvScannerController.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.avscanner.controllers
 
+import play.api.libs.json.Json
 import play.api.mvc._
 import play.api.{Logger, Play}
 import uk.gov.hmrc.avscanner.clamav.{ClamAntiVirus, ClamAvFailedException, VirusChecker, VirusDetectedException}
@@ -52,7 +53,11 @@ trait AvScannerController extends BaseController {
             case virus: VirusDetectedException =>
               Future.successful(Forbidden)
             case f: ClamAvFailedException =>
-              Future.successful(InternalServerError)
+              Future.successful(InternalServerError(
+                Json.obj(
+                  "reason" -> "ClamAV failed",
+                  "detail" -> f.message
+                )))
             case t: Throwable =>
               Logger.warn("Unexpected error occurred whilst scanning file", t)
               throw t

--- a/test/uk/gov/hmrc/avscanner/clamav/ClamAvResponseInterpreterSpec.scala
+++ b/test/uk/gov/hmrc/avscanner/clamav/ClamAvResponseInterpreterSpec.scala
@@ -31,5 +31,13 @@ class ClamAvResponseInterpreterSpec extends UnitSpec with WithFakeApplication {
         interpreter.interpretResponseFromClamd("stream: Eicar-Test-Signature FOUND")
       }
     }
+
+    "throw a ClamAvFailedException on an empty response" in {
+      intercept[ClamAvFailedException] {
+        // we have observed that when clamav fails under high load we get an
+        // empty response
+        interpreter.interpretResponseFromClamd("")
+      }
+    }
   }
 }

--- a/test/uk/gov/hmrc/avscanner/clamav/ClamAvResponseInterpreterSpec.scala
+++ b/test/uk/gov/hmrc/avscanner/clamav/ClamAvResponseInterpreterSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.avscanner.clamav
+
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+class ClamAvResponseInterpreterSpec extends UnitSpec with WithFakeApplication {
+  val interpreter = new ClamAvResponseInterpreter {}
+
+  "Interpreting responses from ClamAV" should {
+    "return without exception on an OK response" in {
+      interpreter.interpretResponseFromClamd("stream: OK")
+    }
+
+    "throw a VirusDetectedException on a FOUND response" in {
+      intercept[VirusDetectedException] {
+        interpreter.interpretResponseFromClamd("stream: Eicar-Test-Signature FOUND")
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/avscanner/clamav/ClamAvResponseInterpreterSpec.scala
+++ b/test/uk/gov/hmrc/avscanner/clamav/ClamAvResponseInterpreterSpec.scala
@@ -23,12 +23,12 @@ class ClamAvResponseInterpreterSpec extends UnitSpec with WithFakeApplication {
 
   "Interpreting responses from ClamAV" should {
     "return without exception on an OK response" in {
-      interpreter.interpretResponseFromClamd("stream: OK")
+      interpreter.interpretResponseFromClamd(Some("stream: OK"))
     }
 
     "throw a VirusDetectedException on a FOUND response" in {
       intercept[VirusDetectedException] {
-        interpreter.interpretResponseFromClamd("stream: Eicar-Test-Signature FOUND")
+        interpreter.interpretResponseFromClamd(Some("stream: Eicar-Test-Signature FOUND"))
       }
     }
 
@@ -36,7 +36,7 @@ class ClamAvResponseInterpreterSpec extends UnitSpec with WithFakeApplication {
       intercept[ClamAvFailedException] {
         // we have observed that when clamav fails under high load we get an
         // empty response
-        interpreter.interpretResponseFromClamd("")
+        interpreter.interpretResponseFromClamd(None)
       }
     }
   }

--- a/test/uk/gov/hmrc/avscanner/clamav/ClamAvSpec.scala
+++ b/test/uk/gov/hmrc/avscanner/clamav/ClamAvSpec.scala
@@ -98,6 +98,18 @@ class ClamAvSpec extends UnitSpec with WithFakeApplication {
     }
   }
 
+  "emptyToNone" should {
+    val clamAv = new ClamAntiVirus()
+
+    "convert an empty response to None" in {
+      clamAv.emptyToNone("") shouldBe None
+    }
+
+    "convert a non-empty response to Some(response)" in {
+      clamAv.emptyToNone("Something") shouldBe Some("Something")
+    }
+  }
+
   private def getPayload(payloadSize: Int = 0, shouldInsertVirusAtPosition: Option[Int] = None) = {
     val payloadData = shouldInsertVirusAtPosition match {
       case Some(position) =>

--- a/test/uk/gov/hmrc/avscanner/controllers/AvScannerControllerWiringSpec.scala
+++ b/test/uk/gov/hmrc/avscanner/controllers/AvScannerControllerWiringSpec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.avscanner.controllers
+
+import uk.gov.hmrc.avscanner.FileBytes
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+class AvScannerControllerWiringSpec extends UnitSpec with WithFakeApplication {
+
+  val avScannerController = new AvScannerController{
+    override val maxLength: Int = Int.MaxValue
+  }
+
+  "anti virus controller in conjunction with clamd" should {
+    "provide a 200 response for no virus present" in {
+
+      status(avScannerController.av(FileBytes(SpecConstants.cleanFile))) shouldBe 200
+    }
+
+    "provide a 403 response for a discovered virus" in {
+
+      status(avScannerController.av(FileBytes(SpecConstants.virusFile))) shouldBe 403
+    }
+  }
+}

--- a/test/uk/gov/hmrc/avscanner/controllers/SpecConstants.scala
+++ b/test/uk/gov/hmrc/avscanner/controllers/SpecConstants.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.avscanner.controllers
+
+object SpecConstants {
+  val cleanFile = "/testfile.txt"
+  val virusFile = "/eicar-standard-av-test-file"
+}


### PR DESCRIPTION
Note: the existing `AvScannerControllerSpec` has been renamed to `AvScannerControllerWiringSpec` and there is a new `AvScannerControllerSpec`, see 386e341b7b6e576189c59127fab85e46a5fd8e71 for details.